### PR TITLE
Use setusercontext(3) if available

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -40,13 +40,14 @@ AC_DEFINE_UNQUOTED(PATH_SU, "$SU_PROG")
 
 dnl Checks for libraries
 dnl ====================
+AC_SEARCH_LIBS(setusercontext, util)
 
 dnl Checks for header files
 dnl =======================
 AC_HEADER_STDC
 AC_HEADER_TIME
-AC_CHECK_HEADERS(limits.h stdarg.h stdlib.h string.h stringlist.h syslog.h \
-	unistd.h sys/syslog.h)
+AC_CHECK_HEADERS(err.h limits.h login_cap.h stdarg.h stdlib.h string.h \
+	stringlist.h syslog.h unistd.h sys/syslog.h)
 
 dnl Checks for typedefs, structures, and compiler characteristics
 dnl =============================================================

--- a/priv.c
+++ b/priv.c
@@ -312,6 +312,17 @@ main(int argc, char **argv, char **envp)
 	}
 
 	/* Set up the permissions */
+#ifdef HAVE_LOGIN_CAP_H
+	if (setusercontext(NULL, pw, pw->pw_uid, LOGIN_SETGROUP |
+	    LOGIN_SETPRIORITY | LOGIN_SETRESOURCES | LOGIN_SETUMASK |
+	    LOGIN_SETUSER) != 0) {
+		sverr = errno;
+		syslog(LOG_NOTICE, "%s: not ok: setusercontext failed: %m",
+		    myfullname);
+		errno = sverr;
+		err(EXIT_VAL, "setusercontext failed");
+	}
+#else
 	if (setgid(pw->pw_gid) < 0) {
 		sverr = errno;
 		syslog(LOG_NOTICE, "%s: not ok: setgid failed: %m", myfullname);
@@ -331,6 +342,7 @@ main(int argc, char **argv, char **envp)
 		errno = sverr;
 		err(EXIT_VAL, "setuid failed");
 	}
+#endif
 
 	/* Check for sym-link */
 	if (!(nflags & F_SYMLINK)) {

--- a/priv.h
+++ b/priv.h
@@ -87,6 +87,14 @@
 # endif
 #endif
 
+#ifdef HAVE_LOGIN_CAP_H
+# include <login_cap.h>
+#endif
+
+#ifdef HAVE_ERR_H
+# include <err.h>
+#endif
+
 #define DEFPATH		"/bin:/usr/bin"
 #define SYSLOGNAME	"priv"			/* name used with syslog */
 #define LOGBUFSIZ	2048 + 256		/* number of chars to log */


### PR DESCRIPTION
On NetBSD setusercontext(3) is necessary for per-user tmp to work.